### PR TITLE
fix: use namePrefix-compatible name for ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: -role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dcontroller-role
+  name: -role
 subjects:
 - kind: ServiceAccount
   name: dcontroller-account


### PR DESCRIPTION
Fixes #7

## Fix

Rename the ClusterRole source from `manager-role` to `-role`, matching the convention used by all other RBAC resources (`-rolebinding`, `-account`, `-leader-election-role`). Also update the roleRef in the ClusterRoleBinding to `-role`.

With `namePrefix: dcontroller`, kustomize now produces `dcontroller-role` for both.

## Commits

1. **fix:** Rename source names in `config/rbac/role.yaml` and `role_binding.yaml`
2. **chore:** Regenerate `chart/helm/templates/all.yaml` via `kustomize build` (also picks up other pending source changes)

## Verification

```
$ kustomize build config/helm-base | grep "name:.*role"
  name: dcontroller-leader-election-role
  name: dcontroller-role
  name: dcontroller-leader-election-rolebinding
  name: dcontroller-leader-election-role
  name: dcontroller-rolebinding
  name: dcontroller-role
```